### PR TITLE
fix: bug in grouping when executing in parallel

### DIFF
--- a/code/groupDevices.js
+++ b/code/groupDevices.js
@@ -3,7 +3,7 @@ const breathe = require('./utils/breathe');
 
 //Groups DEVC entries by device
 async function groupDevices(klv) {
-  result = {};
+  const result = {};
   for (const d of klv.DEVC || []) {
     await breathe();
     //Delete TICK and potentially other unused keys


### PR DESCRIPTION
There is one variable in groupDevices that was not scoped to the
function. It's content was thus shared between different parallel
executions and this caused incorrect results.

The solution is to add `const` to make sure the variable is scoped to
the function.

I tried adding a test but this bug only shows in the browser, not in
Node so the test fails to break when the problem exists.