### PR TITLE
Coordinates Precision – Apply to Interpreted Data

### DIFF
--- a/__tests__/node/coordinatesPrecision.test.js
+++ b/__tests__/node/coordinatesPrecision.test.js
@@ -1,0 +1,19 @@
+const coordinatesPrecision = require('../../code/coordinatesPrecision');
+const { readFileSync } = require('fs');
+
+let result;
+
+describe('Test Coordinates Precision Application', () => {
+  beforeAll(async () => {
+    const file = readFileSync(`${__dirname}/../../samples/partials/mergedGps.json`);
+    result = await coordinatesPrecision(JSON.parse(file), {
+      CoordinatesPrecision: 3
+    });
+  });
+
+  test(`coordinatesPrecision should reduce contrast between samples`, () => {
+      const pickedSample = result['1'].streams.GPS5.samples[10].value
+      expect(pickedSample[0]).toBe(33.126);
+      expect(pickedSample[1]).toBe(-117.327);
+  });
+});

--- a/__tests__/node/index.test.js
+++ b/__tests__/node/index.test.js
@@ -134,6 +134,45 @@ describe('Testing GPS5 with hero7 file', () => {
   });
 });
 
+describe('Testing GPS5 with hero7 file and Coordinates Precision', () => {
+  beforeAll(async () => {
+    filename = 'hero7';
+    file = fs.readFileSync(`${__dirname}/../../samples/${filename}.raw`);
+    result = await goproTelemetry(
+      { rawData: file, timing },
+      {
+        stream: 'GPS5',
+        smooth: 20,
+        GPSPrecision: 140,
+        CoordinatesPrecision: 4,
+        timeIn: 'MP4'
+      }
+    );
+  });
+
+  test(`GPSPrecision should leave us with fewer, better samples`, () => {
+    expect(result['1'].streams.GPS5.samples.length).toBe(219);
+  });
+
+  test(`smooth should return averaged values`, () => {
+    expect(result['1'].streams.GPS5.samples[5].value[0]).toBe(
+      42.3426
+    );
+  });
+
+  test(`coordinates should be precisely set`, () => {
+    expect(result['1'].streams.GPS5.samples[5].value[0]).toBe(
+      42.3426
+    );
+  });
+
+  test(`timeIn: 'MP4' option should use mp4 timing dates`, () => {
+    expect(result['1'].streams.GPS5.samples[0].date).toEqual(
+      '2017-12-31T12:15:27.002Z'
+    );
+  });
+});
+
 describe('Testing with hero6 file', () => {
   slowBeforeAll(async () => {
     filename = 'hero6';

--- a/__tests__/node/toGeojson.test.js
+++ b/__tests__/node/toGeojson.test.js
@@ -26,27 +26,3 @@ describe('Test GeoJSON', () => {
     expect(result.properties.AbsoluteUtcMicroSec[3]).toBe(1492450263165);
   });
 });
-
-describe('Test GeoJSON with Coordinates Precision', () => {
-  beforeAll(async () => {
-    const file = readFileSync(
-      `${__dirname}/../../samples/partials/mergedGps.json`
-    );
-
-    result = await toGeojson(JSON.parse(file), { CoordinatesPrecision: 6 });
-  });
-
-  test(`toGeojson should follow geojson format`, () => {
-    expect(result.geometry.type).toBe('LineString');
-  });
-  test(`toGeojson should contain coordinates`, () => {
-    expect(result.geometry.coordinates[3]).toEqual([
-      -117.327354, 
-      33.126497, 
-      -20.088,
-    ]);
-  });
-  test(`toGeojson should contain timing data`, () => {
-    expect(result.properties.AbsoluteUtcMicroSec[3]).toBe(1492450263165);
-  });
-});

--- a/__tests__/node/toGpx.test.js
+++ b/__tests__/node/toGpx.test.js
@@ -22,26 +22,3 @@ describe('Test GPX', () => {
     );
   });
 });
-
-describe('Test GPX with CoordinatesPrecision', () => {
-  beforeAll(async () => {
-    const file = readFileSync(
-      `${__dirname}/../../samples/partials/mergedGps.json`
-    );
-
-    result = await toGpx(JSON.parse(file), {
-      comment: true,
-      CoordinatesPrecision: 6,
-    });
-  });
-
-  test(`toGpx should return a long string`, () => {
-    expect(result.length).toBeGreaterThan(6000);
-  });
-
-  test(`toGpx should start with xml-gpx format`, () => {
-    expect(result.slice(300, 930).replace(/\s/g, '').trim()).toBe(
-      `<src>Camera</src><trkseg><trkptlat=\"33.126497\"lon=\"-117.327354\"><ele>-20.184</ele><time>2017-04-17T17:31:03.000Z</time><fix>3d</fix><hdop>6.06</hdop><geoidheight>-34.03217630752571</geoidheight><cmt>2dSpeed:0.167;3dSpeed:0.19</cmt></trkpt><trkptlat=\"33.126497\"lon=\"-117.327354\"><ele>-20.146</ele><time>2017-04-17T17:31:03.055Z</time><fix>3d</fix><hdop>6.06</hdop><geoidheight>-34.03217630752571</geoidheight>`
-    );
-  });
-});

--- a/__tests__/node/toKml.test.js
+++ b/__tests__/node/toKml.test.js
@@ -29,29 +29,3 @@ describe('Test KML', () => {
         </Placemark>`);
   });
 });
-
-describe('Test KML with CoordinatesPrecision', () => {
-  beforeAll(async () => {
-    const file = readFileSync(
-      `${__dirname}/../../samples/partials/mergedGps.json`
-    );
-
-    result = await toKml(JSON.parse(file), {
-      comment: true,
-      CoordinatesPrecision: 6,
-    });
-  });
-
-  test(`toKml should export kml placemarks`, () => {
-    expect(result.slice(478, 912)).toBe(`<Placemark>
-            <description>GPS Fix: 3; GPS DOP: 6.06; geoidHeight: -34.03217630752571; 2D Speed: 0.167; 3D Speed: 0.19</description>
-            <Point>
-                <altitudeMode>absolute</altitudeMode>
-                <coordinates>-117.327354,33.126497,-20.184</coordinates>
-            </Point>
-            <TimeStamp>
-                <when>2017-04-17T17:31:03.000Z</when>
-            </TimeStamp>
-        </Placemark>`);
-  });
-});

--- a/__tests__/node/toVirb.test.js
+++ b/__tests__/node/toVirb.test.js
@@ -22,26 +22,3 @@ describe('Test GPS5', () => {
     );
   });
 });
-
-describe('Test GPS5 with Coordinates Precision', () => {
-  beforeAll(async () => {
-    const file = readFileSync(
-      `${__dirname}/../../samples/partials/mergedGps.json`
-    );
-
-    result = await toVirb(JSON.parse(file), {
-      stream: ['GPS5'],
-      CoordinatesPrecision: 6,
-    });
-  });
-
-  test(`toVirb should return a long string`, () => {
-    expect(result.length).toBeGreaterThan(4000);
-  });
-
-  test(`toVirb should start with xml- (virb) format`, () => {
-    expect(result.slice(383, 732).replace(/\s/g, '').trim()).toBe(
-      `<src>Camera</src><trkseg><trkptlat=\"33.126497\"lon=\"-117.327354\"><ele>-20.184</ele><time>2017-04-17T17:31:03Z</time><geoidheight>-34.03217630752571</geoidheight></trkpt><trkptlat=\"33.126497\"lon=\"-117.327354\"><ele>-20.146</ele>`
-    );
-  });
-});

--- a/code/coordinatesPrecision.js
+++ b/code/coordinatesPrecision.js
@@ -1,0 +1,26 @@
+// Apply Chosen Precision Level to GPS Coordinates
+module.exports = async function (
+    interpreted,
+    { CoordinatesPrecision }
+  ) {
+    //Copy input
+    let result = interpreted
+    for (const key in result) {
+      if (result[key].streams) {
+        for (const k in result[key].streams) {
+          const samples = result[key].streams[k].samples;
+          let newSamples = [];
+          if(samples) {
+            for (let i = 0; i < samples.length; i++) {
+              let newSample = samples[i]
+              newSample.value[0] = parseFloat(newSample.value[0].toFixed(CoordinatesPrecision))
+              newSample.value[1] = parseFloat(newSample.value[1].toFixed(CoordinatesPrecision))
+              newSamples.push(newSample)
+            }
+          }
+          result[key].streams[k].samples = newSamples
+        }
+      }
+    }
+    return result
+  }

--- a/code/presets/toGeojson.js
+++ b/code/presets/toGeojson.js
@@ -1,7 +1,7 @@
 const breathe = require('../utils/breathe');
 
 //Returns the GPS data as an object for geojson
-async function getGPSData(data, CoordinatesPrecision) {
+async function getGPSData(data) {
   let properties = {};
   let coordinates = [];
   for (const key in data) {
@@ -34,12 +34,6 @@ async function getGPSData(data, CoordinatesPrecision) {
             //Check that at least we have the valid values
             if (s.value && s.value.length > 1) {
               coordinates[i] = [s.value[1], s.value[0]];
-              if (CoordinatesPrecision != null) {
-                coordinates[i] = [
-                  parseFloat(s.value[1].toFixed(CoordinatesPrecision)),
-                  parseFloat(s.value[0].toFixed(CoordinatesPrecision)),
-                ];
-              }
               //Set elevation if present
               if (s.value.length > 1) coordinates[i].push(s.value[2]);
               //Set time if present
@@ -59,8 +53,8 @@ async function getGPSData(data, CoordinatesPrecision) {
 }
 
 //Converts the processed data to geojson
-module.exports = async function (data, { name, CoordinatesPrecision }) {
-  const converted = await getGPSData(data, CoordinatesPrecision);
+module.exports = async function (data, { name }) {
+  const converted = await getGPSData(data);
   let result = {
     type: 'Feature',
     geometry: {

--- a/code/presets/toGpx.js
+++ b/code/presets/toGpx.js
@@ -7,7 +7,7 @@ const fixes = {
 };
 
 //Returns the GPS data as a string
-async function getGPSData(data, comment, CoordinatesPrecision) {
+async function getGPGS5Data(data, comment) {
   let frameRate;
   let inner = '';
   let device = '';
@@ -107,14 +107,8 @@ async function getGPSData(data, comment, CoordinatesPrecision) {
                 }
               }
               //Create sample string
-              let lat = s.value[0];
-              let lon = s.value[1];
-              if (CoordinatesPrecision != null) {
-                lat = parseFloat(s.value[0].toFixed(CoordinatesPrecision));
-                lon = parseFloat(s.value[1].toFixed(CoordinatesPrecision));
-              }
               const partial = `
-          <trkpt lat="${lat}" lon="${lon}">
+          <trkpt lat="${s.value[0]}" lon="${s.value[1]}">
               ${(ele + time + fix + hdop + geoidHeight + cmt).trim()}
           </trkpt>`;
               if (i === 0 && s.cts > 0) {
@@ -126,7 +120,7 @@ async function getGPSData(data, comment, CoordinatesPrecision) {
                 const firstTime = `
               <time>${firstDate}</time>`;
                 const fakeFirst = `
-          <trkpt lat="${lat}" lon="${lon}">
+          <trkpt lat="${s.value[0]}" lon="${s.value[1]}">
                 ${(ele + firstTime + fix + hdop + geoidHeight + cmt).trim()}
           </trkpt>`;
                 inner += `${fakeFirst}`;
@@ -148,8 +142,8 @@ async function getGPSData(data, comment, CoordinatesPrecision) {
 }
 
 //Converts the processed data to GPX
-module.exports = async function (data, { name, comment, CoordinatesPrecision }) {
-  const converted = await getGPSData(data, comment, CoordinatesPrecision);
+module.exports = async function (data, { name, comment }) {
+  const converted = await getGPGS5Data(data, comment);
   if (!converted) return undefined;
   let string = `\
 <?xml version="1.0" encoding="UTF-8"?>

--- a/code/presets/toKml.js
+++ b/code/presets/toKml.js
@@ -1,7 +1,7 @@
 const breathe = require('../utils/breathe');
 
 //Returns the GPS data as a string
-async function getGPSData(data, comment, CoordinatesPrecision) {
+async function getGPSData(data, comment) {
   let frameRate;
   let device;
   let inner = '';
@@ -89,12 +89,6 @@ async function getGPSData(data, comment, CoordinatesPrecision) {
               }
               //Prepare coordinates
               let coords = [s.value[1], s.value[0]];
-              if (CoordinatesPrecision != null) {
-                coords = [
-                  parseFloat(s.value[1].toFixed(CoordinatesPrecision)),
-                  parseFloat(s.value[0].toFixed(CoordinatesPrecision)),
-                ];
-              }
               //Set elevation if present
               if (s.value.length > 2) {
                 coords.push(s.value[2]);
@@ -131,8 +125,8 @@ async function getGPSData(data, comment, CoordinatesPrecision) {
 }
 
 //Converts the processed data to KML
-module.exports = async function (data, { name, comment, CoordinatesPrecision }) {
-  const converted = await getGPSData(data, comment, CoordinatesPrecision);
+module.exports = async function (data, { name, comment }) {
+  const converted = await getGPSData(data, comment);
   let string = `\
 <?xml version="1.0" encoding="UTF-8"?>
 <kml xmlns="http://www.opengis.net/kml/2.2" xmlns:atom="http://www.w3.org/2005/Atom">

--- a/code/presets/toVirb.js
+++ b/code/presets/toVirb.js
@@ -1,7 +1,7 @@
 const breathe = require('../utils/breathe');
 
 //Returns the GPS data as a string
-async function getGPSData(data, CoordinatesPrecision) {
+async function getGPSData(data) {
   let frameRate;
   let inner = '';
   let device = '';
@@ -57,14 +57,8 @@ async function getGPSData(data, CoordinatesPrecision) {
                 }
               }
               //Create sample string
-              let lat = s.value[0];
-              let lon = s.value[1];
-              if (CoordinatesPrecision != null) {
-                lat = parseFloat(s.value[0].toFixed(CoordinatesPrecision));
-                lon = parseFloat(s.value[1].toFixed(CoordinatesPrecision));
-              }
               const partial = `
-            <trkpt lat="${lat}" lon="${lon}">
+            <trkpt lat="${s.value[0]}" lon="${s.value[1]}">
                 ${(ele + time + geoidHeight).trim()}
             </trkpt>`;
               if (i === 0 && s.cts > 0) {
@@ -82,7 +76,7 @@ async function getGPSData(data, CoordinatesPrecision) {
                 const firstTime = `
                 <time>${firstDate}</time>`;
                 const fakeFirst = `
-            <trkpt lat="${lat}" lon="${lon}">
+            <trkpt lat="${s.value[0]}" lon="${s.value[1]}">
                     ${(ele + firstTime + geoidHeight).trim()}
             </trkpt>`;
                 inner += `${fakeFirst}`;
@@ -197,10 +191,10 @@ async function getACCLData(data) {
 }
 
 //Converts the processed data to GPX
-module.exports = async function (data, { name, stream, CoordinatesPrecision }) {
+module.exports = async function (data, { name, stream }) {
   let converted;
   if (stream[0] === 'GPS5' || stream[0] === 'GPS9') {
-    converted = await getGPSData(data, CoordinatesPrecision);
+    converted = await getGPSData(data);
   } else if (stream[0] === 'ACCL') converted = await getACCLData(data);
   else return undefined;
   if (!converted) return undefined;

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const interpretKLV = require('./code/interpretKLV');
 const mergeStream = require('./code/mergeStream');
 const groupTimes = require('./code/groupTimes');
 const smoothSamples = require('./code/smoothSamples');
+const coordinatesPrecision = require('./code/coordinatesPrecision')
 const processGPS = require('./code/processGPS');
 const filterWrongSpeed = require('./code/filterWrongSpeed');
 const presetsOpts = require('./code/data/presetsOptions');
@@ -318,6 +319,9 @@ async function process(input, opts) {
   progress(opts, 0.6);
 
   await breathe();
+
+  // Apply Coordinates Precision
+  if(opts.CoordinatesPrecision) interpreted = await coordinatesPrecision(interpreted, opts)
 
   //Group samples by time if necessary
   if (opts.groupTimes) interpreted = await groupTimes(interpreted, opts);

--- a/readme.md
+++ b/readme.md
@@ -69,7 +69,7 @@ The options must be an object. The following keys are supported.
 - **WrongSpeed** (number) Will filter out GPS positions that generate higher speeds than indicated in meters per second. This acts on a sample to sample basis, so in order to avoid ignoring generally good samples that produce high speeds due to noise, it is important to set a generous (high) value.
 - **preset** (string) Will convert the final output to the specified format. Some formats will force certain options. See details below.
 - **name** (string) Some preset formats (gpx) accept a name value that will be included in the file.
-- **CoordinatesPrecision** (number) Sets Precision on Coordinates. 6 decimal places is roughly 10cm of precision, 9 would be sufficient for professional survey-grade GPS coordinates. For now, applies only to preset exports (GPX, geoJSON, KML, Virb)
+- **CoordinatesPrecision** (number) Sets Precision on Coordinates. 6 decimal places is roughly 10cm of precision, 9 would be sufficient for professional survey-grade GPS coordinates.
 - **progress** (function) Function to execute when progress (between 0 and 1) is made in the extraction process. Not proportional.
 - **comment** (boolean) Add comments to formats like GPX or KML with fields they do not strictly support, like recorded speed.
 


### PR DESCRIPTION
I have updated the coordinates precision setting to now apply to the interpreted data, thus simplifying the initial approach into a consolidated function call and single testing file. I have also reverted the initial coordinates precision setting on the preset outputs. 

Obviously it then applies to all preset outputs too! If you'd like a test for those let me know.

I pushed it to after the `smoothSamples` function as when smoothing is enabled it was outputting incorrect values such as 12 decimal places when precision was set to 6. 

It now returns precise coordinate values and I have tested this within my own application.