### PR TITLE
Optimized performance by replacing slice method with subarray

### DIFF
--- a/code/parseKLV.js
+++ b/code/parseKLV.js
@@ -15,7 +15,7 @@ function findLastCC(data, start, end) {
     //Retrieve structured data
     let length = 0;
     try {
-      const tempKs = keyAndStructParser.parse(data.slice(start));
+      const tempKs = keyAndStructParser.parse(data.subarray(start));
       if (tempKs.fourCC !== '\u0000\u0000\u0000\u0000') ks = tempKs;
       //But don't process it, go to next
       length = ks.size * ks.repeat;
@@ -67,7 +67,7 @@ async function parseKLV(
       if (start % 20000 === 0) await breathe();
       try {
         //Parse the first 2 sections (64 bits) of each KLV to decide what to do with the third
-        ks = keyAndStructParser.parse(data.slice(start));
+        ks = keyAndStructParser.parse(data.subarray(start));
 
         //Get the length of the value (or values, or nested values)
         length = ks.size * ks.repeat;

--- a/code/parseV.js
+++ b/code/parseV.js
@@ -72,7 +72,7 @@ function parseV(environment, slice, len, specifics) {
     }
     //We pick the necessary function based on data format (stored in types)
     let valParser = getValueParserForType(type, opts);
-    const parsed = valParser.parse(data.slice(slice));
+    const parsed = valParser.parse(data.subarray(slice));
     if (types[type].forceNum) parsed.value = Number(parsed.value);
 
     return parsed.value;


### PR DESCRIPTION
Hi, I think I have identified the reason behind the performance difference between running in browser vs Node.js. Unlike TypedArray.slice(), which generates a new copy of the sliced portion, Buffer.slice() produces a new buffer that shares memory with the original buffer, essentially behaving in the same way as the subarray() method. This discrepancy is why Buffer.slice() has been deprecated.

I ran some tests using three different videos:

| File Size | Version  | Execution Time (s) |
|-----------|----------|----------------|
| 556 MB    | Original | 4.731        |
|        | Updated  | 1.591      |
| 1.8 GB      | Original | 37.730      |
|       | Updated  | 4.596        |
| 6.1     GB  | Original | 396.933      |
|       | Updated  | 15.095       |
